### PR TITLE
[Feature] 모바일 너비로 앱 컨테이너 너비를 조정

### DIFF
--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -1,10 +1,32 @@
 import Head from "next/head";
 import type { AppProps } from "next/app";
-import { ThemeProvider } from "styled-components";
+import styled, { ThemeProvider, css } from "styled-components";
 
 // styles
 import GlobalStyle from "@src/styles/globals";
-import theme from "@src/styles/theme";
+import theme, { size } from "@src/styles/theme";
+
+const Container = styled.div`
+  ${({ theme: defaultTheme }) => css`
+    background-color: ${defaultTheme.color.gray0};
+  `}
+`;
+
+const Content = styled.div`
+  background-color: #fff;
+  height: 100vh;
+  margin: 0 auto;
+  width: ${size.mobile};
+
+  ${({ theme: defaultTheme }) => {
+    const { window } = defaultTheme;
+    return css`
+      ${window.mobile} {
+        width: 100vw;
+      }
+    `;
+  }}
+`;
 
 function MyApp({ Component, pageProps }: AppProps) {
   return (
@@ -18,7 +40,11 @@ function MyApp({ Component, pageProps }: AppProps) {
       </Head>
       <ThemeProvider theme={theme}>
         <GlobalStyle />
-        <Component {...pageProps} />
+        <Container>
+          <Content>
+            <Component {...pageProps} />
+          </Content>
+        </Container>
       </ThemeProvider>
     </>
   );

--- a/src/styles/theme.ts
+++ b/src/styles/theme.ts
@@ -26,10 +26,10 @@ const theme: DefaultTheme = {
     info: "#5bc0de",
   },
   window: {
-    pc: `@media screen and (max-width: ${size.pc}px)`,
-    tab: `@media screen and (max-width: ${size.tab}px)`,
-    mobile: `@media screen and (max-width: ${size.mobile}px)`,
-    mobileS: `@media screen and (max-width: ${size.mobileS}px)`,
+    pc: `@media only screen and (max-width: ${size.pc})`,
+    tab: `@media only screen and (max-width: ${size.tab})`,
+    mobile: `@media only screen and (max-width: ${size.mobile})`,
+    mobileS: `@media only screen and (max-width: ${size.mobileS})`,
   },
 };
 


### PR DESCRIPTION

closed #1

## 변경 사항

웹에서 접속하더라도 모바일 환경에 맞추도록 합니다.
모바일 너비에서 접속 시 가로 너비에 맞추도록 합니다.
** 모바일 너비 기준: 500px 이하

## 확인 방법

`npm run dev` 후 `localhost:3000` 확인

## 스크린샷
<img width="721" alt="스크린샷 2021-10-30 오후 11 32 56" src="https://user-images.githubusercontent.com/40057032/139537421-893f5a5a-c07f-43ed-b499-9a2953ffc06f.png">

