### PR TITLE
[Feature] 401 에러 핸들링

### DIFF
--- a/src/lib/axios.ts
+++ b/src/lib/axios.ts
@@ -1,11 +1,12 @@
 import axios from "axios";
-import { Agent, AgentOptions } from "https";
+import { Agent } from "https";
 
-function createAxiosInstance(options: AgentOptions) {
+function createAxiosInstance() {
   return axios.create({
     httpsAgent: new Agent({
       rejectUnauthorized: false,
     }),
+    withCredentials: true,
   });
 }
 

--- a/src/models/dto/api-response.d.ts
+++ b/src/models/dto/api-response.d.ts
@@ -3,7 +3,7 @@ export interface APIResponse<T> {
 }
 
 export interface APIErrorResponse {
-  statusCode: number;
+  status: number;
   message: string;
   error?: string;
 }

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -26,9 +26,23 @@ const Home: NextPage = observer(() => {
     [userStore],
   );
 
+  const onTest = useCallback(async () => {
+    await userStore.test();
+  }, [userStore]);
+
+  const onRefresh = useCallback(async () => {
+    await userStore.refresh();
+  }, [userStore]);
+
   return (
     <Container>
       <LoginPageTemplate onSubmit={onSubmit} />
+      <button type="button" onClick={onTest}>
+        test auth
+      </button>{" "}
+      <button type="button" onClick={onRefresh}>
+        test refresh
+      </button>
     </Container>
   );
 });

--- a/src/services/Auth.service.ts
+++ b/src/services/Auth.service.ts
@@ -9,4 +9,12 @@ export default class AuthService extends BaseHttpService {
   logout() {
     this.removeToken();
   }
+
+  async test(): Promise<string> {
+    return (await this.get<string>("/test")) as string;
+  }
+
+  async refresh(): Promise<string> {
+    return (await this.post<string>("/refresh")) as string;
+  }
 }

--- a/src/store/user.store.ts
+++ b/src/store/user.store.ts
@@ -22,6 +22,16 @@ export default class UserStore {
 
   async login({ email, password }) {
     const loginDto: LoginDto = UserMapper.buildLoginDto({ email, password });
-    await this.authService.login(loginDto);
+    const token = await this.authService.login(loginDto);
+    this.authService._saveToken(token);
+  }
+
+  async test() {
+    await this.authService.test();
+  }
+
+  async refresh() {
+    const token = await this.authService.refresh();
+    this.authService._saveToken(token);
   }
 }


### PR DESCRIPTION
closed #6 

## 변경 사항
- accessToken 만료로 인한 401 에러를 핸들링합니다.
- 401 에러 발생 시, refresh 요청을 보내 새로운 accessToken을 받아옵니다.
- 토큰을 새로 받아오지 못했을 경우, 로그인 페이지로 이동시킵니다.

## 확인 방법
- test 버튼 클릭
