### PR TITLE
[Feature] useForm 훅 추가

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -20,7 +20,9 @@
   "extends": [
     "airbnb",
     "airbnb/hooks",
+//    "eslint:recommended",
     "plugin:@typescript-eslint/eslint-recommended",
+    "plugin:@typescript-eslint/recommended",
     "plugin:react/recommended",
     "plugin:import/errors",
     "plugin:import/warnings",

--- a/src/hooks/useForm.hook.ts
+++ b/src/hooks/useForm.hook.ts
@@ -1,0 +1,38 @@
+import { ChangeEvent, useCallback, useEffect, useState } from "react";
+
+function useForm<T>({ initialValues, onSubmit, validate }) {
+  const [values, setValues] = useState<T>(initialValues);
+  const [errors, setErrors] = useState({});
+  const [submitting, setSubmitting] = useState(false);
+
+  const handleChange = useCallback(
+    (e: ChangeEvent<HTMLInputElement>) => {
+      const { name, value } = e.target;
+      setValues({ ...values, [name]: value });
+    },
+    [values],
+  );
+
+  const handleSubmit = useCallback(
+    async (e: SubmitEvent) => {
+      setSubmitting(true);
+      e.preventDefault();
+      await new Promise((r) => setTimeout(r, 1000));
+      setErrors(validate(values));
+    },
+    [validate, values],
+  );
+
+  useEffect(() => {
+    if (submitting) {
+      if (Object.keys(errors).length === 0) {
+        onSubmit(values);
+      }
+      setSubmitting(false);
+    }
+  }, [submitting, values, errors, onSubmit]);
+
+  return { values, errors, submitting, handleChange, handleSubmit };
+}
+
+export default useForm;

--- a/src/hooks/useForm.hook.ts
+++ b/src/hooks/useForm.hook.ts
@@ -1,6 +1,27 @@
 import { ChangeEvent, useCallback, useEffect, useState } from "react";
 
-function useForm<T>({ initialValues, onSubmit, validate }) {
+interface useFormProp<T> {
+  initialValues: T;
+  onSubmit(values: T): void;
+  validate(values: T): T;
+}
+
+interface formErrors {
+  [name: string]: string;
+}
+
+interface useFormReturn<T> {
+  values: T;
+  errors: formErrors<T>;
+  submitting: boolean;
+  handleChange(e: ChangeEvent<HTMLInputElement>): void;
+  handleSubmit(e: SubmitEvent): void;
+}
+function useForm<T>({
+  initialValues,
+  onSubmit,
+  validate,
+}: useFormProp<T>): useFormReturn<T> {
   const [values, setValues] = useState<T>(initialValues);
   const [errors, setErrors] = useState({});
   const [submitting, setSubmitting] = useState(false);


### PR DESCRIPTION
## 변경 사항
- useForm 훅을 추가했습니다.
- props<T>
  - T: 폼에 들어가는 값 타입의 제네릭
  - initialValues: 폼 초기 값
  - onSubmit(values): 폼 제출 시 수행할 동작
  - validate(values): 폼 검증 시 수행할 동작
- return
  -  values: 폼 안의 값 상태
  - errors: validate를 거쳐 발생한 에러
  - submitting: validate와 onSubmit을 수행하는 중인지 여부
  - handleChange: 폼 내부 인풋 태그 변경 시 동작
  - handleSubmit: 폼을 제출할 시 동작

closed #4 
