### PR TITLE
[Feature] 닉네임 & 이메일 중복 확인 단계 추가

### DIFF
--- a/src/models/dto/signup.dto.d.ts
+++ b/src/models/dto/signup.dto.d.ts
@@ -6,6 +6,10 @@ export type CheckOverlapEmailDto = {
   email: string;
 };
 
+export type CheckOverlapNicknameDto = {
+  nickname: string;
+};
+
 export type ConfirmCertificationDto = {
   email: string;
   code: string;

--- a/src/pages/signup.tsx
+++ b/src/pages/signup.tsx
@@ -29,16 +29,31 @@ const SignupPage = observer(() => {
       [SignupStep.CONFIRM_EMAIL]: signupStore.emailConfirmed,
       [SignupStep.PASSWORD_INPUT]: signupStore.form.pwd,
       [SignupStep.DETAILS_INPUT]:
-        signupStore.form.univCategory && signupStore.form.nickname,
+        signupStore.form.univCategory &&
+        signupStore.form.nickname &&
+        !signupStore.errors.nickname,
       [SignupStep.SELECT_GIVE_CATEGORY]: true,
       [SignupStep.SELECT_TAKE_CATEGORY]: true,
     }),
-    [signupStore.form, signupStore.emailConfirmed],
+    [
+      signupStore.form.univ,
+      signupStore.form.pwd,
+      signupStore.form.univCategory,
+      signupStore.form.nickname,
+      signupStore.emailConfirmed,
+      signupStore.errors.nickname,
+    ],
   );
 
   const onMoveNext = useCallback(async () => {
     if (step + 1 === SignupStep.COMPLETE_SIGNUP) {
       await signupStore.signup();
+    }
+    if (step === SignupStep.DETAILS_INPUT) {
+      const result = await signupStore.checkNicknameOverlap(
+        signupStore.form.nickname,
+      );
+      if (!result) return;
     }
     setStep((step + 1) as SignupStep);
   }, [step, signupStore]);

--- a/src/services/Signup.service.ts
+++ b/src/services/Signup.service.ts
@@ -2,6 +2,7 @@ import BaseHttpService from "@src/services/BaseHttp.service";
 import { API_PREFIX } from "@src/constant/api.constant";
 import {
   CheckOverlapEmailDto,
+  CheckOverlapNicknameDto,
   ConfirmCertificationDto,
   SendCertificationMailDto,
   SignupForm,
@@ -33,7 +34,14 @@ export default class SignupService extends BaseHttpService {
 
   async checkOverlapEmail(param: CheckOverlapEmailDto): Promise<boolean> {
     return (await this.post<boolean>(
-      `${this.prefix}/overlap`,
+      `${this.prefix}/overlap/email`,
+      param,
+    )) as boolean;
+  }
+
+  async checkOverlapNickname(param: CheckOverlapNicknameDto): Promise<boolean> {
+    return (await this.post<boolean>(
+      `${this.prefix}/overlap/nickname`,
       param,
     )) as boolean;
   }

--- a/src/store/signup.store.ts
+++ b/src/store/signup.store.ts
@@ -91,10 +91,12 @@ export default class SignupStore {
       await this.signupService.checkOverlapNickname({ nickname });
       this.form.nickname = nickname;
       this._cleanErrors();
+      return true;
     } catch (e) {
       if (e.code === 400) {
         this.errors = { nickname: e.message };
       }
+      return false;
     }
   }
 

--- a/src/store/signup.store.ts
+++ b/src/store/signup.store.ts
@@ -86,6 +86,18 @@ export default class SignupStore {
     }
   }
 
+  async checkNicknameOverlap(nickname: string) {
+    try {
+      await this.signupService.checkOverlapNickname({ nickname });
+      this.form.nickname = nickname;
+      this._cleanErrors();
+    } catch (e) {
+      if (e.code === 400) {
+        this.errors = { nickname: e.message };
+      }
+    }
+  }
+
   // 인증 메일 재전송 요청
   async sendAgainCertificationMail() {
     try {


### PR DESCRIPTION
#32 

## 변경 사항
- 닉네임 중복 확인 api 추가
- 디테일 확인 단계에서 다음 버튼 누르면 닉네임 확인하고, 중복이면 넘겨주지 않기
- 이메일 중복 확인 api 변경
