### PR TITLE
[Feature] 이메일 인증 시 제한시간 표시

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "@netlify/plugin-nextjs": "3.9.2",
     "antd": "4.16.13",
     "axios": "0.24.0",
+    "dayjs": "1.10.7",
     "mobx": "6.3.5",
     "mobx-react": "7.2.1",
     "next": "11.1.2",

--- a/src/components/organs/signup/ConfirmEmailStep.component.tsx
+++ b/src/components/organs/signup/ConfirmEmailStep.component.tsx
@@ -17,6 +17,8 @@ import { ErrorMessage } from "@src/components/atoms/text/ErrorMessage";
 import { BaseMarginBottom, BaseProps } from "@src/styles/common";
 import { useStores } from "@src/store/root.store";
 import { observer } from "mobx-react";
+import useTimer from "@src/hooks/useTimer";
+import { EmailConfirmLimitTimeInSeconds } from "@src/constant/policy.constant";
 
 const EmailWrap = styled.div<BaseProps>`
   ${BaseMarginBottom};
@@ -74,6 +76,10 @@ const ConfirmEmailStepComponent = observer(
 
     const [email, setEmail] = useState("");
     const { value: code, handleChange: handleChangeCode } = useInput("");
+
+    const { formatted } = useTimer({
+      limit: requestedMail ? EmailConfirmLimitTimeInSeconds : 0,
+    });
 
     const onChangeEmail = useCallback(
       (e) => {
@@ -144,7 +150,7 @@ const ConfirmEmailStepComponent = observer(
                   disabled={!allowInputCode}
                 />
               }
-              suffix={<span>04:59</span>}
+              suffix={<span>{formatted}</span>}
             />
             <div>
               <Button

--- a/src/components/organs/signup/ConfirmEmailStep.component.tsx
+++ b/src/components/organs/signup/ConfirmEmailStep.component.tsx
@@ -79,6 +79,7 @@ const ConfirmEmailStepComponent = observer(
 
     const { formatted } = useTimer({
       limit: requestedMail ? EmailConfirmLimitTimeInSeconds : 0,
+      onTimerEnded: () => setAllowInputCode(false),
     });
 
     const onChangeEmail = useCallback(

--- a/src/constant/policy.constant.ts
+++ b/src/constant/policy.constant.ts
@@ -1,0 +1,2 @@
+export const EmailConfirmLimitTimeInSeconds = 5 * 60;
+export default {};

--- a/src/constant/policy.constant.ts
+++ b/src/constant/policy.constant.ts
@@ -1,2 +1,2 @@
-export const EmailConfirmLimitTimeInSeconds = 0.1 * 60;
+export const EmailConfirmLimitTimeInSeconds = 5 * 60;
 export default {};

--- a/src/constant/policy.constant.ts
+++ b/src/constant/policy.constant.ts
@@ -1,2 +1,2 @@
-export const EmailConfirmLimitTimeInSeconds = 5 * 60;
+export const EmailConfirmLimitTimeInSeconds = 0.1 * 60;
 export default {};

--- a/src/hooks/useTimer.tsx
+++ b/src/hooks/useTimer.tsx
@@ -3,14 +3,15 @@ import dayjs from "dayjs";
 
 interface TimerProp {
   limit: number;
+  onTimerEnded: () => void;
 }
 
-function useTimer({ limit }: TimerProp) {
+function useTimer({ limit, onTimerEnded }: TimerProp) {
   const [minutes, setMinutes] = useState(0);
   const [seconds, setSeconds] = useState(0);
 
   useEffect(() => {
-    setMinutes(limit / 60);
+    setMinutes(parseInt((limit / 60).toString(), 10));
     setSeconds(limit % 60);
   }, [limit]);
   useEffect(() => {
@@ -20,6 +21,7 @@ function useTimer({ limit }: TimerProp) {
       }
       if (seconds === 0) {
         if (minutes === 0) {
+          onTimerEnded();
           clearInterval(timer);
         } else {
           setMinutes(minutes - 1);
@@ -29,7 +31,7 @@ function useTimer({ limit }: TimerProp) {
     }, 1000);
 
     return () => clearInterval(timer);
-  }, [limit, minutes, seconds]);
+  }, [limit, minutes, onTimerEnded, seconds]);
 
   const formatted = useMemo(
     () => dayjs().minute(minutes).second(seconds).format("mm:ss"),

--- a/src/hooks/useTimer.tsx
+++ b/src/hooks/useTimer.tsx
@@ -1,0 +1,42 @@
+import { useEffect, useMemo, useState } from "react";
+import dayjs from "dayjs";
+
+interface TimerProp {
+  limit: number;
+}
+
+function useTimer({ limit }: TimerProp) {
+  const [minutes, setMinutes] = useState(0);
+  const [seconds, setSeconds] = useState(0);
+
+  useEffect(() => {
+    setMinutes(limit / 60);
+    setSeconds(limit % 60);
+  }, [limit]);
+  useEffect(() => {
+    const timer = setInterval(() => {
+      if (seconds > 0) {
+        setSeconds(seconds - 1);
+      }
+      if (seconds === 0) {
+        if (minutes === 0) {
+          clearInterval(timer);
+        } else {
+          setMinutes(minutes - 1);
+          setSeconds(59);
+        }
+      }
+    }, 1000);
+
+    return () => clearInterval(timer);
+  }, [limit, minutes, seconds]);
+
+  const formatted = useMemo(
+    () => dayjs().minute(minutes).second(seconds).format("mm:ss"),
+    [minutes, seconds],
+  );
+
+  return { minutes, seconds, formatted };
+}
+
+export default useTimer;

--- a/src/store/signup.store.ts
+++ b/src/store/signup.store.ts
@@ -80,7 +80,7 @@ export default class SignupStore {
       return true;
     } catch (e) {
       if (e.code === 400) {
-        this.errors = { email: e.message };
+        this.errors = { email: e.data };
       }
       return false;
     }
@@ -94,7 +94,7 @@ export default class SignupStore {
       return true;
     } catch (e) {
       if (e.code === 400) {
-        this.errors = { nickname: e.message };
+        this.errors = { nickname: e.data };
       }
       return false;
     }
@@ -112,7 +112,7 @@ export default class SignupStore {
       return true;
     } catch (e) {
       if (e.code === 400) {
-        this.errors = { email: e.message };
+        this.errors = { email: e.data };
       }
       return false;
     }
@@ -129,11 +129,12 @@ export default class SignupStore {
 
       this._cleanErrors();
       this.emailConfirmed = true;
+      this.errors = { email: "인증되었습니다." };
 
       return true;
     } catch (e) {
       if (e.code === 400) {
-        this.errors = { email: e.message };
+        this.errors = { email: e.data };
       }
       return false;
     }

--- a/src/templates/SignupPage.template.tsx
+++ b/src/templates/SignupPage.template.tsx
@@ -11,10 +11,10 @@ import ConfirmEmailStepComponent from "@src/components/organs/signup/ConfirmEmai
 import PasswordInputStepComponent from "@src/components/organs/signup/PasswordInputStep.component";
 import DetailsInputStepComponent from "@src/components/organs/signup/DetailsInputStep.component";
 import SelectCategoryStepComponent from "@src/components/organs/signup/SelectCategoryStep.component";
+import SignupCompleteStepComponent from "@src/components/organs/signup/SignupCompleteStep.component";
 import LeftArrowIcon from "@src/components/icon/LeftArrow.icon";
 import { Button } from "@src/components/atoms/Button";
 import { TextButton } from "@src/components/atoms/LinkButton";
-import SignupCompleteStepComponent from "@src/components/organs/signup/SignupCompleteStep.component";
 
 // styles
 import theme, { FontSize, Padding, windowSize } from "@src/styles/theme";
@@ -83,7 +83,7 @@ export type SignupTemplateProps = {
   onClickNext?: () => void;
   onClickPrev?: () => void;
   onCheckConfirmMail?: (email: string) => void;
-  onClickReqConfirmMail?: (code: string) => void;
+  onClickReqConfirmMail?: (email: string) => Promise<boolean>;
   onToggleCategory?: (type: CategoryType, id: number) => void;
   selectedUniv: Univ;
   isStepCompleted: object;


### PR DESCRIPTION
#29 

## 변경 사항
- 이메일을 입력해야 인증번호 버튼을 활성화
- 인증 메일을 한 번 받은 후에는 [다시 받기]로 버튼 내용을 변경
- 발송 성공 시 인증 코드 입력칸과 완료 버튼을 표시
- 입력이 가능한 동안 타이머를 동작 (현재 5분)
- 타이머가 종료되면 인증 입력창 및 버튼을 비활성화
- 이메일 중복, 코드 오류 등의 오류 메시지를 하단에 표시

## 확인 방법
- 회원 가입 중 이메일 인증 단계에서 인증번호 발송 후 확인

## 스크린샷
![image](https://user-images.githubusercontent.com/40057032/141158143-50a810ab-b004-48c4-bcb0-48ec84dcc467.png)

