### PR TITLE
[Release] v0.2.2 로그인 완료 시 이메일 표시 및 로그아웃 버튼 추가

### DIFF
--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,7 +1,26 @@
 import GuestMainTemplate from "@src/templates/GuestMain.template";
+import { useStores } from "@src/store/root.store";
+import { useEffect, useMemo, useState } from "react";
+import UserMainTemplate from "@src/templates/UserMain.template";
 
 function MainPage() {
-  return <GuestMainTemplate />;
+  const { userStore } = useStores();
+
+  const [email, setEmail] = useState("");
+  // TODO :: authenticated 확인을 HOC로 빼내기
+  const authenticated = useMemo(() => userStore.isAuthenticated(), [userStore]);
+
+  useEffect(() => {
+    if (authenticated) {
+      userStore.test().then((x) => setEmail(x));
+    }
+  }, [authenticated, userStore]);
+
+  return authenticated ? (
+    <UserMainTemplate email={email} />
+  ) : (
+    <GuestMainTemplate />
+  );
 }
 
 export default MainPage;

--- a/src/pages/login.tsx
+++ b/src/pages/login.tsx
@@ -26,7 +26,7 @@ const LoginPage: NextPage = observer(() => {
       await userStore.login(values);
       router.push("/");
     },
-    [userStore],
+    [router, userStore],
   );
 
   const { values, handleSubmit, handleChange } = useForm<LoginForm>({

--- a/src/pages/login.tsx
+++ b/src/pages/login.tsx
@@ -13,15 +13,18 @@ import useForm from "@src/hooks/useForm.hook";
 import LoginPageTemplate, {
   LoginForm,
 } from "@src/templates/LoginPage.template";
+import { useRouter } from "next/router";
 
 const Container = styled.div``;
 
 const LoginPage: NextPage = observer(() => {
   const { userStore } = useStores();
+  const router = useRouter();
 
   const onSubmit = useCallback(
     async (values) => {
       await userStore.login(values);
+      router.push("/");
     },
     [userStore],
   );

--- a/src/pages/logout.tsx
+++ b/src/pages/logout.tsx
@@ -1,0 +1,33 @@
+import { useEffect } from "react";
+import { useStores } from "@src/store/root.store";
+import { useRouter } from "next/router";
+import styled from "styled-components";
+
+const Container = styled.div`
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  width: 100%;
+  height: 100vh;
+`;
+
+function LogoutPage() {
+  const { userStore } = useStores();
+  const router = useRouter();
+
+  useEffect(() => {
+    userStore.logout();
+    setTimeout(() => {
+      router.push("/");
+    }, 2000);
+  }, [router, userStore]);
+
+  return (
+    <Container>
+      <p>로그아웃 되었습니다.</p>
+    </Container>
+  );
+}
+
+export default LogoutPage;

--- a/src/services/BaseHttp.service.ts
+++ b/src/services/BaseHttp.service.ts
@@ -137,17 +137,18 @@ export default class BaseHttpService {
 
   _saveToken(accessToken: string) {
     this._accessToken = accessToken;
-    return localStorage.setItem("accessToken", accessToken);
+    return localStorage?.setItem("accessToken", accessToken);
   }
 
   loadToken() {
-    const token: string | null = localStorage.getItem("accessToken");
+    if (typeof window === "undefined") return null;
+    const token: string | null = localStorage?.getItem("accessToken");
     this._accessToken = token;
     return token;
   }
 
   removeToken() {
     this._accessToken = null;
-    localStorage.removeItem("accessToken");
+    localStorage?.removeItem("accessToken");
   }
 }

--- a/src/store/user.store.ts
+++ b/src/store/user.store.ts
@@ -26,12 +26,22 @@ export default class UserStore {
     this.authService._saveToken(token);
   }
 
+  logout() {
+    this.authService.logout();
+  }
+
   async test() {
-    await this.authService.test();
+    const email = await this.authService.test();
+    return email;
   }
 
   async refresh() {
     const token = await this.authService.refresh();
     this.authService._saveToken(token);
+  }
+
+  isAuthenticated() {
+    const token = this.authService.accessToken;
+    return token !== null && token.length > 0;
   }
 }

--- a/src/templates/UserMain.template.tsx
+++ b/src/templates/UserMain.template.tsx
@@ -1,0 +1,27 @@
+import Link from "next/link";
+import { Button } from "@src/components/atoms/Button";
+import styled from "styled-components";
+
+const Container = styled.div`
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  width: 100%;
+  height: 100vh;
+  text-align: center;
+  padding: 40vh 20px;
+`;
+function UserMainTemplate({ email }) {
+  return (
+    <Container>
+      <div>email: {email}</div>
+      <Link href="/logout">
+        <a>
+          <Button color="primary">로그아웃</Button>
+        </a>
+      </Link>
+    </Container>
+  );
+}
+
+export default UserMainTemplate;


### PR DESCRIPTION
## 변경 사항
- 로그인 한 상태이면 메인에서 이메일을 표시
- 로그아웃 페이지로 이동하면 액세스 토큰을 지우고 3초 뒤 메인으로 이동\
- userStore에서 인증 여부를 확인하는 함수를 추가

## 확인 방법
로그인을 완료하기

## 스크린샷
![스크린샷 2021-11-11 오후 4 04 24](https://user-images.githubusercontent.com/40057032/141253211-453c2187-2d56-4e4a-98c7-c38371f66f8f.png)

