### PR TITLE
[Feature] 스터디 참여 신청 폼과 완료 팝업 UI

### DIFF
--- a/src/components/atoms/BottomSection.tsx
+++ b/src/components/atoms/BottomSection.tsx
@@ -12,7 +12,7 @@ export const BottomSection = styled.div<BottomProps>`
   height: ${({ height }) => height ?? "68px"};
   background: #fff;
   border-top: 1px solid ${theme.color.gray2};
-  z-index: 9999;
+  z-index: 5000;
   ${theme.window.tab} {
     width: ${windowSize.mobile};
     left: auto;

--- a/src/components/atoms/Input.tsx
+++ b/src/components/atoms/Input.tsx
@@ -47,4 +47,8 @@ export const UnderlineInput = styled.input<InputStyleProps>`
 export const LightUnderlineInput = styled.input<InputStyleProps>`
   ${LightUnderline};
   ${BaseInput};
+
+  &:disabled {
+    background-color: #fff;
+  }
 `;

--- a/src/components/atoms/Textarea.tsx
+++ b/src/components/atoms/Textarea.tsx
@@ -1,0 +1,22 @@
+import styled from "styled-components";
+import theme from "@src/styles/theme";
+import { BaseProps, BaseStyleProps } from "@src/styles/common";
+
+export const Textarea = styled.textarea<BaseProps>`
+  ${BaseStyleProps};
+  width: 100%;
+  border-radius: 9px;
+  border: 1px solid ${theme.color.primary};
+  padding: 8px;
+
+  &:placeholder-shown {
+    border: 1px solid ${theme.color.gray3};
+  }
+
+  &:focus {
+    outline: none;
+    border: 1px solid ${theme.color.primary};
+  }
+`;
+
+export default { Textarea };

--- a/src/components/molecules/TitleHeader.component.tsx
+++ b/src/components/molecules/TitleHeader.component.tsx
@@ -17,7 +17,7 @@ const Container = styled.div`
   background-color: #fff;
   height: 60px;
 
-  z-index: 9999;
+  z-index: 5000;
 
   ${theme.window.tab} {
     width: ${windowSize.mobile};

--- a/src/components/organs/PageWrapper.component.tsx
+++ b/src/components/organs/PageWrapper.component.tsx
@@ -1,12 +1,14 @@
+import styled from "styled-components";
+
+// components
 import TitleHeaderComponent from "@src/components/molecules/TitleHeader.component";
 import { BottomSection } from "@src/components/atoms/BottomSection";
-import { Button } from "@src/components/atoms/Button";
-import styled from "styled-components";
+
+// styles
 import { NoScroll } from "@src/styles/common";
-import { Padding } from "@src/styles/theme";
 
 const Container = styled.div`
-  padding-top: 60px;
+  padding-top: 80px;
   padding-bottom: 80px;
   overflow: auto;
   height: 100vh;

--- a/src/components/organs/PageWrapper.component.tsx
+++ b/src/components/organs/PageWrapper.component.tsx
@@ -1,0 +1,36 @@
+import TitleHeaderComponent from "@src/components/molecules/TitleHeader.component";
+import { BottomSection } from "@src/components/atoms/BottomSection";
+import { Button } from "@src/components/atoms/Button";
+import styled from "styled-components";
+import { NoScroll } from "@src/styles/common";
+import { Padding } from "@src/styles/theme";
+
+const Container = styled.div`
+  padding-top: 60px;
+  padding-bottom: 80px;
+  overflow: auto;
+  height: 100vh;
+  ${NoScroll};
+`;
+
+const SubmitWrapper = styled.div`
+  position: absolute;
+  right: 20px;
+  top: 0;
+  bottom: 0;
+  display: flex;
+  align-items: center;
+`;
+function PageWrapperComponent({ title, backLink, button, children }) {
+  return (
+    <Container>
+      <TitleHeaderComponent title={title} backLink={backLink} />
+      <div>{children}</div>
+      <BottomSection>
+        <SubmitWrapper>{button}</SubmitWrapper>
+      </BottomSection>
+    </Container>
+  );
+}
+
+export default PageWrapperComponent;

--- a/src/components/organs/Popup.component.tsx
+++ b/src/components/organs/Popup.component.tsx
@@ -1,0 +1,38 @@
+import styled from "styled-components";
+
+import { Button } from "@src/components/atoms/Button";
+
+const Wrapper = styled.div`
+  position: fixed;
+  left: 0;
+  right: 0;
+  top: 0;
+  bottom: 0;
+  background-color: rgba(0, 0, 0, 0.3);
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  padding: 0 40px;
+`;
+
+const Modal = styled.div`
+  background-color: #fff;
+  width: 100%;
+  height: auto;
+  border-radius: 10px;
+  padding: 12px;
+  text-align: center;
+`;
+
+function PopupComponent({ content, bottom }) {
+  return (
+    <Wrapper>
+      <Modal>
+        <div>{content}</div>
+        <div>{bottom}</div>
+      </Modal>
+    </Wrapper>
+  );
+}
+
+export default PopupComponent;

--- a/src/components/organs/Popup.component.tsx
+++ b/src/components/organs/Popup.component.tsx
@@ -1,7 +1,5 @@
 import styled from "styled-components";
 
-import { Button } from "@src/components/atoms/Button";
-
 const Wrapper = styled.div`
   position: fixed;
   left: 0;
@@ -13,6 +11,7 @@ const Wrapper = styled.div`
   justify-content: center;
   align-items: center;
   padding: 0 40px;
+  z-index: 9999;
 `;
 
 const Modal = styled.div`

--- a/src/stories/organs/Popup.stories.tsx
+++ b/src/stories/organs/Popup.stories.tsx
@@ -1,0 +1,35 @@
+import PopupComponent from "@src/components/organs/Popup.component";
+import { Button } from "@src/components/atoms/Button";
+import StudyJoinSuccessModalComponent from "@src/stories/templates/StudyJoinSuccessModal.component";
+
+export default {
+  title: "organs/Popup",
+  component: PopupComponent,
+};
+
+const bottom = (
+  <div>
+    <Button color="point" fontSize="small" height="48px" mb="10px">
+      스터디 관리로 이동
+    </Button>
+    <Button color="white" fontSize="small" filled={false} height="48px">
+      글 목록으로
+    </Button>
+  </div>
+);
+
+const content = (
+  <div style={{ padding: "15px 0 10px 0" }}>
+    <h3 style={{ fontSize: "16px" }}>스터디 참여 신청 완료!</h3>
+    <p style={{ fontSize: "14px" }}>
+      신청 내역 및 스터디 선정 여부는
+      <br />
+      스터디 관리에서 확인하세요!
+    </p>
+  </div>
+);
+const Template = () => <PopupComponent bottom={bottom} content={content} />;
+
+export const Popup = Template.bind({});
+
+export const StudyJoinSuccessModal = () => <StudyJoinSuccessModalComponent />;

--- a/src/stories/templates/StudyJoinForm.stories.tsx
+++ b/src/stories/templates/StudyJoinForm.stories.tsx
@@ -1,0 +1,10 @@
+import StudyJoinFormTemplate from "@src/templates/StudyJoinForm.template";
+
+export default {
+  title: "template/Study Join Form",
+  component: StudyJoinFormTemplate,
+};
+
+const Template = () => <StudyJoinFormTemplate />;
+
+export const StudyJoinForm = Template.bind({});

--- a/src/stories/templates/StudyJoinForm.stories.tsx
+++ b/src/stories/templates/StudyJoinForm.stories.tsx
@@ -1,10 +1,26 @@
 import StudyJoinFormTemplate from "@src/templates/StudyJoinForm.template";
+import { StudyDetailDto } from "@src/models/dto/study.dto";
 
 export default {
   title: "template/Study Join Form",
   component: StudyJoinFormTemplate,
 };
 
-const Template = () => <StudyJoinFormTemplate />;
+const studySample: StudyDetailDto = {
+  id: 1,
+  title: "애프터 이펙트 알려주실 분 구합니다.",
+  contents:
+    "저는 영상을 배우고 싶은데 혹시 영상러들 중 일러스트 관심잇으신 분 계신가요?",
+  location: "아주대학교 카탈로그",
+  peopleCnt: 1,
+  startDate: "2021-11-07T00:00:00.000+00:00",
+  endDate: "2021-11-09T00:00:00.000+00:00",
+  createdAt: "2021-07-21T00:00:00.000+00:00",
+  give: ["요리", "베이킹"],
+  take: ["운동", "영상 편집"],
+  img: "https://cdn.pixabay.com/photo/2021/09/01/16/09/cake-6591719__340.jpg",
+};
+
+const Template = () => <StudyJoinFormTemplate study={studySample} />;
 
 export const StudyJoinForm = Template.bind({});

--- a/src/stories/templates/StudyJoinSuccessModal.component.tsx
+++ b/src/stories/templates/StudyJoinSuccessModal.component.tsx
@@ -1,0 +1,30 @@
+import { Button } from "@src/components/atoms/Button";
+import PopupComponent from "@src/components/organs/Popup.component";
+
+const bottom = (
+  <div>
+    <Button color="point" fontSize="small" height="48px" mb="10px">
+      스터디 관리로 이동
+    </Button>
+    <Button color="white" fontSize="small" filled={false} height="48px">
+      글 목록으로
+    </Button>
+  </div>
+);
+const contentPadding = { padding: "15px 0 10px 0" };
+const content = (
+  <div style={contentPadding}>
+    <h3>스터디 참여 신청 완료!</h3>
+    <p>
+      신청 내역 및 스터디 선정 여부는
+      <br />
+      스터디 관리에서 확인하세요!
+    </p>
+  </div>
+);
+
+function StudyJoinSuccessModalComponent() {
+  return <PopupComponent bottom={bottom} content={content} />;
+}
+
+export default StudyJoinSuccessModalComponent;

--- a/src/templates/StudyCreate.template.tsx
+++ b/src/templates/StudyCreate.template.tsx
@@ -10,23 +10,14 @@ import { Button } from "@src/components/atoms/Button";
 import { LightUnderlineInput } from "@src/components/atoms/Input";
 import DatePicker from "@src/components/atoms/DatePicker";
 import Select from "@src/components/atoms/Select";
-import TitleHeaderComponent from "@src/components/molecules/TitleHeader.component";
 import AutocompleteCategoryComponent from "@src/components/molecules/AutocompleteCategory.component";
+import { BoldDivider } from "@src/components/atoms/Divider";
+import PageWrapperComponent from "@src/components/organs/PageWrapper.component";
 
 // styles
 import theme, { Padding } from "@src/styles/theme";
-import { LightUnderline, NoScroll } from "@src/styles/common";
-import { BottomSection } from "@src/components/atoms/BottomSection";
-import { BoldDivider } from "@src/components/atoms/Divider";
+import { LightUnderline } from "@src/styles/common";
 
-const Container = styled.div`
-  padding-top: 60px;
-  padding-bottom: 80px;
-  height: 100vh;
-  overflow: auto;
-
-  ${NoScroll};
-`;
 const FormWrapper = styled.div`
   padding: 0 ${Padding.pageX};
   input,
@@ -70,11 +61,6 @@ const WithPrefixIcon = styled.div`
   align-items: center;
 `;
 
-const SubmitWrapper = styled.div`
-  position: absolute;
-  right: ${Padding.pageX};
-  top: 10px;
-`;
 function StudyCreateTemplate({
   onSubmit,
   values,
@@ -90,8 +76,21 @@ function StudyCreateTemplate({
 }) {
   const studyTypeList = useMemo(() => getStudyTypeList(), []);
   return (
-    <Container>
-      <TitleHeaderComponent title="스터디 생성" backLink="/" />
+    <PageWrapperComponent
+      title="스터디 생성"
+      backLink="/"
+      button={
+        <Button
+          onClick={onSubmit}
+          width="100px"
+          height="44px"
+          color="primary"
+          fontSize="small"
+        >
+          게시물 작성
+        </Button>
+      }
+    >
       <FormWrapper>
         <LightUnderlineInput
           name="title"
@@ -184,20 +183,7 @@ function StudyCreateTemplate({
           onChange={onChange}
         />
       </FormWrapper>
-      <BottomSection>
-        <SubmitWrapper>
-          <Button
-            onClick={onSubmit}
-            width="100px"
-            height="44px"
-            color="primary"
-            fontSize="small"
-          >
-            게시물 작성
-          </Button>
-        </SubmitWrapper>
-      </BottomSection>
-    </Container>
+    </PageWrapperComponent>
   );
 }
 

--- a/src/templates/StudyCreate.template.tsx
+++ b/src/templates/StudyCreate.template.tsx
@@ -13,6 +13,7 @@ import Select from "@src/components/atoms/Select";
 import AutocompleteCategoryComponent from "@src/components/molecules/AutocompleteCategory.component";
 import { BoldDivider } from "@src/components/atoms/Divider";
 import PageWrapperComponent from "@src/components/organs/PageWrapper.component";
+import { Textarea } from "@src/components/atoms/Textarea";
 
 // styles
 import theme, { Padding } from "@src/styles/theme";
@@ -40,13 +41,6 @@ const WithUnderline = styled.div`
   padding-top: 8px;
   padding-bottom: 0;
   margin-bottom: 5px;
-`;
-
-const Textarea = styled.textarea`
-  width: 100%;
-  border-radius: 9px;
-  border: 1px solid ${theme.color.gray3};
-  padding: 8px;
 `;
 
 const MidLine = styled.hr`

--- a/src/templates/StudyDetail.template.tsx
+++ b/src/templates/StudyDetail.template.tsx
@@ -1,25 +1,22 @@
 import Image from "@src/components/atoms/Image";
-import ProfileFrameComponent from "@src/components/molecules/ProfileFrame.component";
-import StarIcon from "@src/components/icon/Star.icon";
+import styled from "styled-components";
+
+// lib
 import { dateToFormatted } from "@src/utils/dayjs.util";
-import { LightDivider } from "@src/components/atoms/Divider";
-import StudyInfoComponent from "@src/components/molecules/StudyInfo.component";
+
+// components
+import StarIcon from "@src/components/icon/Star.icon";
 import ColoredPinIcon from "@src/components/icon/ColoredPin.icon";
 import ColoredCopyIcon from "@src/components/icon/ColoredCopy.icon";
-import styled from "styled-components";
-import theme, { FontSize, Padding, windowSize } from "@src/styles/theme";
-import { BottomSection } from "@src/components/atoms/BottomSection";
+import { LightDivider } from "@src/components/atoms/Divider";
 import { Button } from "@src/components/atoms/Button";
-import TitleHeaderComponent from "@src/components/molecules/TitleHeader.component";
-import { NoScroll } from "@src/styles/common";
+import ProfileFrameComponent from "@src/components/molecules/ProfileFrame.component";
+import StudyInfoComponent from "@src/components/molecules/StudyInfo.component";
+import PageWrapperComponent from "@src/components/organs/PageWrapper.component";
 
-const Container = styled.div`
-  padding-top: 60px;
-  padding-bottom: 80px;
-  overflow: auto;
-  height: 100vh;
-  ${NoScroll};
-`;
+// styles
+import theme, { FontSize, Padding, windowSize } from "@src/styles/theme";
+
 const StudyContentsWrapper = styled.div`
   padding: 20px ${Padding.pageX} 0;
   h3 {
@@ -80,18 +77,17 @@ const StudyWrapper = styled.div`
   margin-top: 20px;
 `;
 
-const SubmitWrapper = styled.div`
-  position: absolute;
-  right: 20px;
-  top: 0;
-  bottom: 0;
-  display: flex;
-  align-items: center;
-`;
 function StudyDetailTemplate({ study }) {
   return (
-    <Container>
-      <TitleHeaderComponent title="" backLink="/" />
+    <PageWrapperComponent
+      title=""
+      backLink="/"
+      button={
+        <Button color="point" height="44px" fontSize="small" width="100px">
+          참여 신청
+        </Button>
+      }
+    >
       {/* Thumbnail */}
       <ImageWrapper>
         <Image alt={study.title} />
@@ -129,14 +125,7 @@ function StudyDetailTemplate({ study }) {
         {/* Contents */}
         <StudyWrapper>{study.contents}</StudyWrapper>
       </StudyContentsWrapper>
-      <BottomSection>
-        <SubmitWrapper>
-          <Button color="point" height="44px" fontSize="small" width="100px">
-            참여 신청
-          </Button>
-        </SubmitWrapper>
-      </BottomSection>
-    </Container>
+    </PageWrapperComponent>
   );
 }
 

--- a/src/templates/StudyJoinForm.template.tsx
+++ b/src/templates/StudyJoinForm.template.tsx
@@ -1,0 +1,21 @@
+// components
+import { Button } from "@src/components/atoms/Button";
+import PageWrapperComponent from "@src/components/organs/PageWrapper.component";
+
+function StudyJoinFormTemplate() {
+  return (
+    <PageWrapperComponent
+      title=""
+      backLink="/"
+      button={
+        <Button color="point" height="44px" fontSize="small" width="100px">
+          참여 신청
+        </Button>
+      }
+    >
+      hi
+    </PageWrapperComponent>
+  );
+}
+
+export default StudyJoinFormTemplate;

--- a/src/templates/StudyJoinForm.template.tsx
+++ b/src/templates/StudyJoinForm.template.tsx
@@ -1,11 +1,33 @@
+import styled from "styled-components";
+
 // components
 import { Button } from "@src/components/atoms/Button";
 import PageWrapperComponent from "@src/components/organs/PageWrapper.component";
 
-function StudyJoinFormTemplate() {
+// styles
+import { FontSize, Padding } from "@src/styles/theme";
+import { LightUnderlineInput } from "@src/components/atoms/Input";
+import { Textarea } from "@src/components/atoms/Textarea";
+import { BaseProps, BaseStyleProps } from "@src/styles/common";
+
+const ContentsWrapper = styled.div`
+  padding: ${Padding.page};
+`;
+
+const FormWrapper = styled.div`
+  margin-bottom: 20px;
+`;
+const Label = styled.p<BaseProps>`
+  margin-bottom: 0;
+  ${BaseStyleProps};
+  font-size: ${FontSize.Default};
+  font-weight: 500;
+  padding-left: 10px;
+`;
+function StudyJoinFormTemplate({ study }) {
   return (
     <PageWrapperComponent
-      title=""
+      title="참여 신청"
       backLink="/"
       button={
         <Button color="point" height="44px" fontSize="small" width="100px">
@@ -13,7 +35,20 @@ function StudyJoinFormTemplate() {
         </Button>
       }
     >
-      hi
+      <ContentsWrapper>
+        <FormWrapper>
+          <Label>참여 스터디</Label>
+          <LightUnderlineInput placeholder={study.title} disabled />
+        </FormWrapper>
+        <FormWrapper>
+          <Label mb="10px">신청 동기 및 기타 사항</Label>
+          <Textarea
+            fontSize="small"
+            rows={10}
+            placeholder="스터디에 대한 관심 및 제안 사항을 입력해주세요!"
+          />
+        </FormWrapper>
+      </ContentsWrapper>
     </PageWrapperComponent>
   );
 }

--- a/src/templates/StudyJoinForm.template.tsx
+++ b/src/templates/StudyJoinForm.template.tsx
@@ -9,6 +9,7 @@ import { FontSize, Padding } from "@src/styles/theme";
 import { LightUnderlineInput } from "@src/components/atoms/Input";
 import { Textarea } from "@src/components/atoms/Textarea";
 import { BaseProps, BaseStyleProps } from "@src/styles/common";
+import StudyJoinSuccessModalComponent from "@src/stories/templates/StudyJoinSuccessModal.component";
 
 const ContentsWrapper = styled.div`
   padding: ${Padding.page};
@@ -49,6 +50,7 @@ function StudyJoinFormTemplate({ study }) {
           />
         </FormWrapper>
       </ContentsWrapper>
+      <StudyJoinSuccessModalComponent />
     </PageWrapperComponent>
   );
 }


### PR DESCRIPTION
## 변경 사항
- 헤더-바텀 픽스드 컴포넌트를 PageWrapper로 감싸 분리
- 참여 신청 폼 UI를 추가 
- 팝업 컴포넌트를 추가
- 참여 신청 완료 메시지 표시를 위한 팝업 컴포넌트를 추가

## 확인 방법
- 스토리북 확인

## 스크린샷
![스크린샷 2021-11-14 오전 4 02 39](https://user-images.githubusercontent.com/40057032/141656089-b912aacf-683c-4350-a4f0-ffc065d59adb.png)
![스크린샷 2021-11-14 오전 4 02 56](https://user-images.githubusercontent.com/40057032/141656095-211804ee-7711-4397-b554-b322d6ac3e39.png)


