### PR TITLE
[Fix] 모바일 기기 높이에 따라 로그인 페이지 패딩을 조정

### DIFF
--- a/src/components/molecules/AppTitle.component.tsx
+++ b/src/components/molecules/AppTitle.component.tsx
@@ -47,7 +47,7 @@ type Props = {
 function AppTitleComponent({ mb = "0" }: Props) {
   return (
     <S.Container mb={mb}>
-      <S.MainTitle mb="40px">
+      <S.MainTitle mb="20px">
         재능교환?
         <br />A piece of <S.Strong>Cake</S.Strong> 이지
       </S.MainTitle>

--- a/src/styles/template/GuestMain.styles.tsx
+++ b/src/styles/template/GuestMain.styles.tsx
@@ -8,7 +8,12 @@ const Container = styled.div<BaseProps>`
   ${BaseStyleProps};
   background-color: ${theme.color.point};
   height: 100vh;
+
   padding-top: 20vh;
+
+  @media (max-height: 670px) {
+    padding-top: 10vh;
+  }
   padding-left: ${Padding.pageX};
   padding-right: ${Padding.pageX};
 `;

--- a/src/templates/GuestMain.template.tsx
+++ b/src/templates/GuestMain.template.tsx
@@ -11,7 +11,7 @@ import SGuestMain from "@src/styles/template/GuestMain.styles";
 function GuestMainTemplate() {
   return (
     <SGuestMain.Container>
-      <AppTitleComponent mb="100px" />
+      <AppTitleComponent mb="60px" />
       <SGuestMain.ContentsWrap mb="20px">
         <Link href="/login">
           <a>

--- a/src/templates/LoginPage.template.tsx
+++ b/src/templates/LoginPage.template.tsx
@@ -32,7 +32,7 @@ export type LoginForm = {
 function LoginPageTemplate({ onSubmit, onChange, values }): JSX.Element {
   return (
     <SGuestMain.Container>
-      <AppTitleComponent mb="100px" />
+      <AppTitleComponent mb="60px" />
       <S.ContentsWrap mb="20px" onSubmit={onSubmit}>
         <DividedInput
           height="65px"


### PR DESCRIPTION
## 변경 사항
- 작은 휴대폰에서 로그인 페이지가 잘리던 것을 수정

## 스크린샷
![스크린샷 2021-11-14 오후 5 32 51](https://user-images.githubusercontent.com/40057032/141673730-33b0dc9f-fab8-4e43-aeb2-04d52dc20a0a.png)

