### PR TITLE
[Feature] useCopyClipboard 훅 추가 - 버튼 눌러서 복사하기

### DIFF
--- a/src/hooks/useCopyClipboard.hook.ts
+++ b/src/hooks/useCopyClipboard.hook.ts
@@ -1,0 +1,23 @@
+import { useCallback, useState } from "react";
+
+function useCopyClipboardHook(text) {
+  const [copied, setCopied] = useState<boolean>(false);
+
+  const onCopy = useCallback(
+    async (e) => {
+      try {
+        await navigator.clipboard.writeText(text);
+        setCopied(true);
+      } catch (err) {
+        // eslint-disable-next-line no-console
+        console.error(err);
+        setCopied(false);
+      }
+    },
+    [text],
+  );
+
+  return [copied, onCopy];
+}
+
+export default useCopyClipboardHook;

--- a/src/templates/StudyDetail.template.tsx
+++ b/src/templates/StudyDetail.template.tsx
@@ -16,9 +16,10 @@ import SimpleProfileComponent from "@src/components/molecules/SimpleProfile.comp
 
 // styles
 import theme, { FontSize, Padding, windowSize } from "@src/styles/theme";
-import { useMemo } from "react";
+import { MouseEventHandler, useMemo } from "react";
 import LoadingComponent from "@src/components/molecules/Loading.component";
 import ImageGalleryComponent from "@src/components/molecules/ImageGallery.component";
+import useCopyClipboardHook from "@src/hooks/useCopyClipboard.hook";
 
 const StudyContentsWrapper = styled.div`
   padding: 20px ${Padding.pageX} 0;
@@ -47,16 +48,25 @@ const LocationWrapper = styled.div`
   display: flex;
   align-items: center;
   font-size: ${FontSize.Small};
+  gap: 5px;
+  div {
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    overflow: hidden;
+  }
+  p {
+    margin-bottom: 0;
+  }
   button {
     cursor: pointer;
-    margin-left: 5px;
+    margin-left: 10px;
     background-color: transparent;
     outline: none;
     border: 0;
     display: flex;
     align-items: center;
     color: ${theme.color.primary};
-    width: 70px;
+    width: 80px;
     float: right;
     font-size: ${FontSize.Small};
   }
@@ -69,6 +79,8 @@ const StudyWrapper = styled.div`
 `;
 
 function StudyDetailTemplate({ study }) {
+  const [copied, onCopy] = useCopyClipboardHook(study?.storeAddress || "");
+
   const applyButton = useMemo(
     () =>
       !study || !study.apply ? (
@@ -124,12 +136,15 @@ function StudyDetailTemplate({ study }) {
                 <ColoredPinIcon />
               </div>
               <div>
-                <span>{study.storeName}</span>
-                <span>({study.storeAddress})</span>
+                <p>{study.storeName}</p>
+                <p>{study.storeAddress}</p>
               </div>
-              <button type="button">
+              <button
+                type="button"
+                onClick={onCopy as MouseEventHandler<HTMLButtonElement>}
+              >
                 <ColoredCopyIcon />
-                <div>복사</div>
+                {copied ? <div>복사 완료!</div> : <div>복사</div>}
               </button>
             </LocationWrapper>
           )}


### PR DESCRIPTION
## 변경 사항
- 스터디 상세 보기에서 주소 옆에 복사 버튼을 표시, 누르면 클립보드에 복사됨

## 스크린샷
<img width="493" alt="스크린샷 2021-11-17 오후 1 48 21" src="https://user-images.githubusercontent.com/40057032/142136626-377cc7e6-b038-4948-a555-0737df2dff96.png">

closed #89 
