### PR TITLE
[Feature] 필터링 결과 페이지

### DIFF
--- a/src/components/atoms/Select.tsx
+++ b/src/components/atoms/Select.tsx
@@ -126,6 +126,7 @@ function SelectComponent<T>({
         selected={selected}
         placeholder={placeholder}
         onChange={onSelect}
+        onSelect={onSelect}
         shape={shape}
       >
         {options}

--- a/src/components/organs/BottomNavigation.component.tsx
+++ b/src/components/organs/BottomNavigation.component.tsx
@@ -46,7 +46,7 @@ function BottomNavigationComponent({ selected = NaviType.MAIN }) {
             </Description>
           </NavButton>
         </Link>
-        <Link href="/search">
+        <Link href="/filter">
           <NavButton type="button">
             <CategoryMenuIcon selected={selected === NaviType.FILTER} />
             <Description selected={selected === NaviType.FILTER}>

--- a/src/components/organs/CategorySelectDrawer.component.tsx
+++ b/src/components/organs/CategorySelectDrawer.component.tsx
@@ -51,6 +51,7 @@ function CategorySelectDrawerComponent({
   selectedList,
   setSelectedList,
   title = "",
+  multiple = true,
 }) {
   const { categoryStore } = useStores();
 
@@ -64,9 +65,10 @@ function CategorySelectDrawerComponent({
 
       if (found)
         setSelectedList(originalList.filter((x) => x.id !== selected.id));
-      else setSelectedList([...originalList, selected]);
+      else if (multiple) setSelectedList([...originalList, selected]);
+      else setSelectedList([selected]);
     },
-    [selectedList, setSelectedList],
+    [multiple, selectedList, setSelectedList],
   );
 
   useEffect(() => {

--- a/src/pages/filter/index.tsx
+++ b/src/pages/filter/index.tsx
@@ -1,0 +1,44 @@
+import FilteringTemplate from "@src/templates/Filtering.template";
+import { useCallback, useMemo, useState } from "react";
+import { useRouter } from "next/router";
+import { StudyType } from "@src/constant/enum.constant";
+import { withAuthentication } from "@src/hooks/withAuthentication.hoc";
+import { AuthPermissionType } from "@src/constant/api.constant";
+
+function SearchPage() {
+  const router = useRouter();
+
+  const [selectedMine, setSelectedMine] = useState([]);
+  const [selectedYours, setSelectedYours] = useState([]);
+  const [studyType, setStudyType] = useState(StudyType.OneToOne);
+
+  const allowSearch = useMemo(
+    () => selectedMine.length > 0 && selectedYours.length > 0 && studyType,
+    [selectedMine, selectedYours, studyType],
+  );
+  const onSelectStudyType = useCallback((e) => {
+    setStudyType(e.target.value);
+  }, []);
+  const onClickSearch = useCallback(() => {
+    router.push(
+      `/search?give=${selectedMine[0].id}&take=${selectedYours[0].id}&type=${studyType}`,
+    );
+  }, [router, selectedMine, selectedYours, studyType]);
+
+  return (
+    <FilteringTemplate
+      selectedMine={selectedMine}
+      setSelectedMine={setSelectedMine}
+      selectedYours={selectedYours}
+      setSelectedYours={setSelectedYours}
+      studyType={studyType}
+      setStudyType={onSelectStudyType}
+      allowSearch={allowSearch}
+      onClickSearch={onClickSearch}
+    />
+  );
+}
+
+export default SearchPage;
+export const getServersideProps = (ctx) =>
+  withAuthentication(ctx, AuthPermissionType.USER);

--- a/src/pages/filter/index.tsx
+++ b/src/pages/filter/index.tsx
@@ -1,12 +1,15 @@
 import FilteringTemplate from "@src/templates/Filtering.template";
-import { useCallback, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import { useRouter } from "next/router";
 import { StudyType } from "@src/constant/enum.constant";
 import { withAuthentication } from "@src/hooks/withAuthentication.hoc";
 import { AuthPermissionType } from "@src/constant/api.constant";
+import { useStores } from "@src/store/root.store";
+import { observer } from "mobx-react";
 
-function SearchPage() {
+const SearchPage = observer(() => {
   const router = useRouter();
+  const { categoryStore } = useStores();
 
   const [selectedMine, setSelectedMine] = useState([]);
   const [selectedYours, setSelectedYours] = useState([]);
@@ -25,6 +28,15 @@ function SearchPage() {
     );
   }, [router, selectedMine, selectedYours, studyType]);
 
+  useEffect(() => {
+    if (router.query.take) {
+      const found = categoryStore.categoryList.find(
+        (x) => x.id.toString() === router.query.take,
+      );
+      if (found) setSelectedYours([found]);
+    }
+  }, [categoryStore.categoryList, router]);
+
   return (
     <FilteringTemplate
       selectedMine={selectedMine}
@@ -37,7 +49,7 @@ function SearchPage() {
       onClickSearch={onClickSearch}
     />
   );
-}
+});
 
 export default SearchPage;
 export const getServersideProps = (ctx) =>

--- a/src/pages/search/index.tsx
+++ b/src/pages/search/index.tsx
@@ -1,18 +1,49 @@
-import FilteringTemplate from "@src/templates/Filtering.template";
-import { useState } from "react";
+import SearchResultTemplate from "@src/templates/SearchResult.template";
+import { withAuthentication } from "@src/hooks/withAuthentication.hoc";
+import { AuthPermissionType } from "@src/constant/api.constant";
+import useInfiniteLoading from "@src/hooks/useInfiniteLoading.hook";
+import { useStores } from "@src/store/root.store";
+import { useRouter } from "next/router";
+import { useCallback } from "react";
 
-function SearchPage() {
-  const [selectedMine, setSelectedMine] = useState([]);
-  const [selectedYours, setSelectedYours] = useState([]);
+function SearchResultPage() {
+  const router = useRouter();
+  const { studyStore } = useStores();
+
+  const getNextItems = useCallback(
+    async (page) =>
+      studyStore.getFilteredStudy(
+        page,
+        router.query.take,
+        router.query.give,
+        router.query.type,
+      ),
+    [router, studyStore],
+  );
+
+  const {
+    items: studyList,
+    hasMore,
+    onNext,
+  } = useInfiniteLoading({
+    ready:
+      router.query.take !== undefined &&
+      router.query.give !== undefined &&
+      router.query.type !== undefined,
+    getItems: getNextItems,
+    pageToLoad: 0,
+    listKeyName: "study",
+  });
 
   return (
-    <FilteringTemplate
-      selectedMine={selectedMine}
-      setSelectedMine={setSelectedMine}
-      selectedYours={selectedYours}
-      setSelectedYours={setSelectedYours}
+    <SearchResultTemplate
+      studyList={studyList}
+      hasMore={hasMore}
+      onNext={onNext}
     />
   );
 }
 
-export default SearchPage;
+export default SearchResultPage;
+export const getServersideProps = (ctx) =>
+  withAuthentication(ctx, AuthPermissionType.USER);

--- a/src/services/Study.service.ts
+++ b/src/services/Study.service.ts
@@ -22,12 +22,12 @@ export default class StudyService extends BaseHttpService {
 
   async getFilteredStudy(
     page: number,
-    give: number,
-    take: number,
-    type: StudyType,
+    give: string | string[],
+    take: string | string[],
+    type: string | string[],
   ): Promise<StudyListElement[]> {
     return (await this.get<StudyListElement[]>(
-      `/page?page=${page}&give=${give}&take=${take}&type=${type}`,
+      `/page/filter?page=${page}&give=${give}&take=${take}&type=${type}`,
     )) as StudyListElement[];
   }
 

--- a/src/store/study.store.ts
+++ b/src/store/study.store.ts
@@ -31,9 +31,9 @@ export default class StudyStore {
 
   async getFilteredStudy(
     page: number,
-    give: number,
-    take: number,
-    type: StudyType,
+    give: string | string[],
+    take: string | string[],
+    type: string | string[],
   ): Promise<StudyListElement[]> {
     return (await this.studyService.getFilteredStudy(
       page,

--- a/src/stories/templates/Filtering.stories.tsx
+++ b/src/stories/templates/Filtering.stories.tsx
@@ -1,5 +1,5 @@
 import FilteringTemplate from "@src/templates/Filtering.template";
-import SearchPage from "@src/pages/search";
+import SearchPage from "@src/pages/filter";
 
 export default {
   title: "template/Filtering",

--- a/src/templates/Filtering.template.tsx
+++ b/src/templates/Filtering.template.tsx
@@ -10,6 +10,7 @@ import { GuestMain } from "@src/styles/template/GuestMain.styles";
 import { Category } from "@src/components/atoms/Category";
 import useVisibleHook from "@src/hooks/useVisible.hook";
 import CategorySelectDrawerComponent from "@src/components/organs/CategorySelectDrawer.component";
+import AutoCompleteInputComponent from "@src/components/molecules/AutoCompleteInput.component";
 
 const Wrapper = styled.div`
   padding: 20px ${Padding.pageX} 0;
@@ -50,6 +51,10 @@ function FilteringTemplate({
   setSelectedMine,
   selectedYours,
   setSelectedYours,
+  studyType,
+  setStudyType,
+  allowSearch,
+  onClickSearch,
 }) {
   const studyList = useMemo(() => getStudyTypeList(), []);
   const [mineVisible, setMineVisible, setMineInvisible] = useVisibleHook(false);
@@ -106,8 +111,8 @@ function FilteringTemplate({
       <Wrapper>
         <SectionWrapper>
           <LabelWrapper>
-            <h3>나의 재능</h3>
-            <span>다른 사람에게 줄 수 있는 재능은?</span>
+            <h3>Give</h3>
+            <span>다른 사람에게 줄 수 있는 것은 무엇인가요?</span>
           </LabelWrapper>
           <Button
             height="56px"
@@ -125,8 +130,8 @@ function FilteringTemplate({
         </SectionWrapper>
         <SectionWrapper>
           <LabelWrapper>
-            <h3>배우고 싶은 재능</h3>
-            <span>배우고 싶은 재능은?</span>
+            <h3>Take</h3>
+            <span>다른 사람에게 받고 싶은 것은 무엇인가요?</span>
           </LabelWrapper>
           <Button
             height="56px"
@@ -151,15 +156,20 @@ function FilteringTemplate({
             placeholder="여러명이서, 한 명만?"
             shape="rounded"
             color="primary"
-            onSelect={null}
-            selected="0"
+            onSelect={setStudyType}
+            selected={studyType}
             list={studyList}
             idKeyName="key"
             labelKeyName="value"
           />
         </SectionWrapper>
         <GuestMain.BottomWrap>
-          <Button color="primary" width="100%" disabled>
+          <Button
+            color="primary"
+            width="100%"
+            disabled={!allowSearch}
+            onClick={onClickSearch}
+          >
             스터디 검색
           </Button>
         </GuestMain.BottomWrap>

--- a/src/templates/Filtering.template.tsx
+++ b/src/templates/Filtering.template.tsx
@@ -98,6 +98,7 @@ function FilteringTemplate({
         buttonTextOnEmpty="아직 없어요"
         onClose={setMineInvisible}
         visible={mineVisible}
+        multiple={false}
       />
       <CategorySelectDrawerComponent
         title="관심 있거나 배우고 싶은 주제를 선택해주세요."
@@ -106,6 +107,7 @@ function FilteringTemplate({
         buttonTextOnEmpty="다 좋아요!"
         onClose={setYourInvisible}
         visible={yoursVisible}
+        multiple={false}
       />
 
       <Wrapper>

--- a/src/templates/SearchResult.template.tsx
+++ b/src/templates/SearchResult.template.tsx
@@ -1,0 +1,27 @@
+import PageWrapperComponent from "@src/components/organs/PageWrapper.component";
+import BottomNavigationComponent from "@src/components/organs/BottomNavigation.component";
+import { NaviType } from "@src/constant/enum.constant";
+import styled from "styled-components";
+import { Padding } from "@src/styles/theme";
+import StudyListComponent from "@src/components/organs/StudyList.component";
+
+const Wrapper = styled.div`
+  padding: 0 ${Padding.pageX};
+`;
+
+function SearchResultTemplate({ studyList, hasMore, onNext }) {
+  return (
+    <PageWrapperComponent title="스터디 필터링" button={null}>
+      <Wrapper>
+        <StudyListComponent
+          studyList={studyList}
+          onClickNext={onNext}
+          hasMore={hasMore}
+        />
+      </Wrapper>
+      <BottomNavigationComponent selected={NaviType.FILTER} />
+    </PageWrapperComponent>
+  );
+}
+
+export default SearchResultTemplate;

--- a/src/templates/UserMain.template.tsx
+++ b/src/templates/UserMain.template.tsx
@@ -1,5 +1,5 @@
 import Link from "next/link";
-import { useCallback, useMemo } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 
 // components
 import { Button } from "@src/components/atoms/Button";
@@ -20,6 +20,7 @@ import PencilIcon from "@src/components/icon/Pencil.icon";
 import { useRouter } from "next/router";
 import { NaviType } from "@src/constant/enum.constant";
 import StudyListComponent from "@src/components/organs/StudyList.component";
+import { useStores } from "@src/store/root.store";
 
 const MainContainer = styled.div`
   ${NoScroll};
@@ -95,6 +96,14 @@ function UserMainTemplate({
   onClickNext = () => null,
   hasMore = false,
 }) {
+  const { categoryStore } = useStores();
+  const [categoryList, setCategoryList] = useState([]);
+  useEffect(() => {
+    categoryStore
+      .getCategoryList()
+      .then((list) => setCategoryList(list.slice(3, 6)));
+  }, [categoryStore]);
+
   const router = useRouter();
   const onClickCreateStudy = useCallback(() => {
     router.push("/study/create");
@@ -132,10 +141,14 @@ function UserMainTemplate({
         <Button color="white">더보기</Button>
       </Banner>
       <CurationSectionsWrapper>
-        <h2>방금 올라온 따끈한 스터디 🍰</h2>
+        <h2>이런거 배워 보면 어때요? 🍰</h2>
         <CategoryListElementWrapper>
-          {categories.map((x) => (
-            <CategoryTag key={x}>{x}</CategoryTag>
+          {categoryList.map((x) => (
+            <Link key={x.id} href={`/filter?take=${x.id}`}>
+              <a>
+                <CategoryTag>{x.name}</CategoryTag>
+              </a>
+            </Link>
           ))}
         </CategoryListElementWrapper>
       </CurationSectionsWrapper>


### PR DESCRIPTION
## 변경 사항
- 필터링 검색 페이지에서 모든 칸 입력하지 않으면 검색 불가
- 카테고리 선택 prop에 'multiple' 추가, false일 경우 하나만 선택 가능함
- 메인의 '이런거 배워보면 어때요' 추천 카테고리를 누르면 take가 채워진 필터링 페이지로 이동
- 결과 페이지에서 url 쿼리에 따라 결과 리스트 표시

## 스크린샷
<img width="328" alt="스크린샷 2021-11-17 오후 4 23 39" src="https://user-images.githubusercontent.com/40057032/142154755-58833983-f7fe-4eb3-8983-80c385b1b5e0.png">

