### PR TITLE
[Fix] 스터디 관리 페이지 키 에러 수정

### DIFF
--- a/src/templates/MyStudyList.template.tsx
+++ b/src/templates/MyStudyList.template.tsx
@@ -52,8 +52,7 @@ function MyStudyListTemplate({ studyList = [] }) {
   const studyListDOM = useMemo(
     () =>
       studyList.map((x, index) => (
-        // eslint-disable-next-line react/no-array-index-key
-        <div key={x.id + index}>
+        <div key={x.id}>
           <StudyManageListElementComponent study={x} />
           {index < studyList.length - 1 && <BoldDivider />}
         </div>


### PR DESCRIPTION
## 변경 사항
- 원래 스터디 ID 중복 및 중복 신청 가능했는데, 이를 방지하려고 스터디 id에 index를 더한 값으로 각 component key값을 정해주었음. 그 결과 스터디끼리 키 중복이 발생해서 탭 이동 시 리스트 갱신이 제대로 되지 않음
