### PR TITLE
[Fix] API 콜 횟수 줄이기

### DIFF
--- a/src/components/organs/StudyList.component.tsx
+++ b/src/components/organs/StudyList.component.tsx
@@ -6,7 +6,7 @@ import useIntersectionObserver from "@src/hooks/useIntersectionObserver.hook";
 import styled from "styled-components";
 
 const ListWrapper = styled.div`
-  min-height: 50vh;
+  min-height: 70vh;
 `;
 const ThresholdWrapper = styled.div`
   height: 20px;
@@ -17,7 +17,7 @@ function StudyListComponent({ studyList, hasMore, loading, onClickNext }) {
 
   useEffect(
     () => !loading && hasMore && entry && onClickNext(),
-    [entry, hasMore, loading, onClickNext],
+    [loading, hasMore, entry, onClickNext],
   );
 
   const studyListDom = useMemo(

--- a/src/hooks/useInfiniteLoading.hook.ts
+++ b/src/hooks/useInfiniteLoading.hook.ts
@@ -5,32 +5,36 @@ const useInfiniteLoading = ({
   getItems,
   pageToLoad = 0,
   listKeyName,
+  pageSize = 19,
 }) => {
   const [items, setItems] = useState([]);
   const [page, setPage] = useState(pageToLoad);
   const initialPageLoaded = useRef(false);
-  const [hasMore, setHasMore] = useState(true);
-  const [loading, setLoading] = useState(false);
+  const [hasMore, setHasMore] = useState(false);
+  const [loading, setLoading] = useState(true);
 
   const loadItems = useCallback(
     async (nextPage) => {
       /* 3 */
       const data = await getItems(nextPage);
-      if (data[listKeyName].length === 0) setHasMore(false);
-      else {
+      if (data[listKeyName].length < pageSize) {
+        setHasMore(false);
+      } else {
         setHasMore(true); /* 4 */
-        setItems((prevItems) => [...prevItems, ...data[listKeyName]]);
       }
+      setItems((prevItems) => [...prevItems, ...data[listKeyName]]);
       setLoading(false);
     },
-    [getItems, listKeyName],
+    [getItems, listKeyName, pageSize],
   );
 
   const onNext = useCallback(() => {
-    setPage(page + 1);
-    setLoading(true);
-    loadItems(page + 1);
-  }, [loadItems, page]);
+    if (!loading && hasMore) {
+      setPage(page + 1);
+      setLoading(true);
+      loadItems(page + 1);
+    }
+  }, [hasMore, loadItems, loading, page]);
 
   useEffect(() => {
     if (!ready) return;

--- a/src/services/BaseHttp.service.ts
+++ b/src/services/BaseHttp.service.ts
@@ -32,7 +32,7 @@ export default class BaseHttpService {
       .get<APIResponse<T>>(`${this.BASE_URL}${path}`, options)
       .then((res: AxiosResponse<APIResponse<T>>) => res.data.data)
       .catch((error: AxiosError<APIErrorResponse>) =>
-        this._handleHttpError(error),
+        this._handleHttpError<T>(error),
       );
   }
 
@@ -46,7 +46,7 @@ export default class BaseHttpService {
       .post<APIResponse<T>>(`${this.BASE_URL}${path}`, data, options)
       .then((res: AxiosResponse<APIResponse<T>>) => res.data.data)
       .catch((error: AxiosError<APIErrorResponse>) =>
-        this._handleHttpError(error),
+        this._handleHttpError<T>(error),
       );
   }
 
@@ -59,7 +59,7 @@ export default class BaseHttpService {
       .delete<APIResponse<T>>(`${this.BASE_URL}${path}`, options)
       .then((res: AxiosResponse<APIResponse<T>>) => res.data.data)
       .catch((error: AxiosError<APIErrorResponse>) =>
-        this._handleHttpError(error),
+        this._handleHttpError<T>(error),
       );
   }
 
@@ -73,7 +73,7 @@ export default class BaseHttpService {
       .patch<APIResponse<T>>(`${this.BASE_URL}${path}`, data, options)
       .then((res: AxiosResponse<APIResponse<T>>) => res.data.data)
       .catch((error: AxiosError<APIErrorResponse>) =>
-        this._handleHttpError(error),
+        this._handleHttpError<T>(error),
       );
   }
 
@@ -88,24 +88,24 @@ export default class BaseHttpService {
       )
       .then((res: AxiosResponse<APIResponse<T>>) => res.data.data)
       .catch((error: AxiosError<APIErrorResponse>) =>
-        this._handleHttpError(error),
+        this._handleHttpError<T>(error),
       );
   }
 
-  _handleHttpError(error: AxiosError<APIErrorResponse>) {
+  _handleHttpError<T>(error: AxiosError<APIErrorResponse>) {
     if (error?.response?.data) {
       const { status } = error?.response?.data;
       if (status !== 401) {
         throw error.response.data;
       } else {
-        return this._handle401(error);
+        return this._handle401<T>(error);
       }
     } else {
       throw error;
     }
   }
 
-  _handle401(error: AxiosError<APIErrorResponse>) {
+  _handle401<T>(error: AxiosError<APIErrorResponse>) {
     this.removeToken();
 
     // refresh token
@@ -121,11 +121,17 @@ export default class BaseHttpService {
             .headers as AxiosRequestHeaders;
           return this.axiosInstance.request(config);
         })
+        .then((res: AxiosResponse<APIResponse<T>>) => {
+          console.log("hi! ", res.data.data);
+          return res.data.data;
+        })
         .catch(() => {
           this.removeToken();
           Router.push("/login");
+        })
+        .finally(() => {
+          this._sentRefresh = false;
         });
-      this._sentRefresh = false;
     }
   }
 


### PR DESCRIPTION
closed #140  #136 

## 변경 사항
- 메인 페이지 등 Infinite Scroll 사용하는 페이지에서 api 콜이 한 번에 많이 날아가는 현상 있었음. 필요한 만큼만 콜 하도록 변경함
- infiniteScroll 훅에서 초기 설정을 loading=true, hasmore=false로 하여 0번 페이지 응답을 받기 전에 1, 2, 3번 페이지 응답을 보내지 않게 함
- infiniteScroll 컴포넌트 기본 높이를 70vh로 하여 entry 컴포넌트가 화면에서 충분히 벗어나게 함.


## 스크린샷
### 수정 전
![스크린샷 2021-11-28 오후 3 34 41](https://user-images.githubusercontent.com/40057032/143732257-41339cd9-7813-4942-9add-a9c9fe49d56f.png)

### 수정 후
![스크린샷 2021-11-28 오후 3 34 22](https://user-images.githubusercontent.com/40057032/143732249-c1c6bbcf-cb64-4e5e-8ebd-b5c508b23885.png)

